### PR TITLE
Fix GitHub capitalization in button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -124,7 +124,7 @@ export default function Home() {
         <div className="mt-10 flex justify-center">
           <Button asChild>
             <a href="https://github.com/banana-hammers/origins.git" target="_blank" rel="noopener noreferrer">
-              Get Github Repo
+              Get GitHub Repo
             </a>
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- update button text from `Get Github Repo` to `Get GitHub Repo`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c52d6782483269e750c41468807ab