### PR TITLE
Rename lore page to planner

### DIFF
--- a/docs/SidePanelChat.md
+++ b/docs/SidePanelChat.md
@@ -1,7 +1,7 @@
-# Technical Specification: OpenAI Chat Side Panel for "Where are we" Button
+# Technical Specification: OpenAI Chat Side Panel for Task Planner
 
 ## Overview
-We'll implement a side panel that slides in from the right when the user clicks the "Where are we" button. This panel will contain a chat interface where users can interact with OpenAI to learn about their location in the fictional world.
+We'll implement a side panel that slides in from the right when the user starts the task planner. This panel will contain a chat interface where users can get help organizing their work.
 
 ## Component Structure
 1. Create a new `ChatPanel` component for the side panel
@@ -42,7 +42,7 @@ Key features:
 
 ### 4. Update Planner Page
 Location: `/src/app/planner/page.tsx`
-Purpose: Add the chat panel and connect it to the "Where are we" button
+Purpose: Add the chat panel and connect it to the task planner button
 
 Key changes:
 - Import the ChatPanel component
@@ -60,7 +60,7 @@ The following state will be needed:
 We'll use the existing OpenAI integration:
 - Use the `streamTextGenerationWithState` function from `streamClient.ts`
 - Build conversation history to provide context
-- Use a system prompt that sets the context for the chat about the fictional world
+- Use a system prompt that sets the context for helping the user plan tasks
 
 ## UI/UX Considerations
 - Add a smooth animation for the panel sliding in/out
@@ -95,12 +95,12 @@ We'll use the existing OpenAI integration:
 ### 4. Update the Planner Page
 1. Import the ChatPanel component in `/src/app/planner/page.tsx`
 2. Add state to control the panel's visibility
-3. Update the "Where are we" button to toggle the panel
+3. Update the planner button to toggle the panel
 4. Add the ChatPanel component to the JSX
 5. Pass the necessary props to control the panel
 
 ### 5. Test the Implementation
-1. Verify that the "Where are we" button opens the side panel
+1. Verify that the planner button opens the side panel
 2. Confirm that the welcome message appears when the panel opens
 3. Test sending messages and receiving responses
 4. Verify that the streaming responses work correctly
@@ -121,7 +121,7 @@ IMPLEMENTATION CHECKLIST:
 12. Add header with title and close button to panel
 13. Import ChatPanel component in `/src/app/planner/page.tsx`
 14. Add state to control panel visibility in planner page
-15. Update "Where are we" button to toggle panel
+15. Update the planner button to toggle panel
 16. Add ChatPanel component to planner page JSX
 17. Test button opens side panel correctly
 18. Verify welcome message appears when panel opens

--- a/docs/SidePanelChat.md
+++ b/docs/SidePanelChat.md
@@ -7,7 +7,7 @@ We'll implement a side panel that slides in from the right when the user clicks 
 1. Create a new `ChatPanel` component for the side panel
 2. Create a `ChatMessage` component to render individual messages
 3. Create a `ChatInput` component for user input
-4. Update the lore page to use these components
+4. Update the planner page to use these components
 
 ## Detailed Specifications
 
@@ -40,8 +40,8 @@ Key features:
 - Disable input while waiting for AI response
 - Handle Enter key to send message
 
-### 4. Update Lore Page
-Location: `/src/app/lore/page.tsx`
+### 4. Update Planner Page
+Location: `/src/app/planner/page.tsx`
 Purpose: Add the chat panel and connect it to the "Where are we" button
 
 Key changes:
@@ -92,8 +92,8 @@ We'll use the existing OpenAI integration:
 7. Add scrolling container for the message history
 8. Add a header with title and close button
 
-### 4. Update the Lore Page
-1. Import the ChatPanel component in `/src/app/lore/page.tsx`
+### 4. Update the Planner Page
+1. Import the ChatPanel component in `/src/app/planner/page.tsx`
 2. Add state to control the panel's visibility
 3. Update the "Where are we" button to toggle the panel
 4. Add the ChatPanel component to the JSX
@@ -119,10 +119,10 @@ IMPLEMENTATION CHECKLIST:
 10. Add welcome message when panel first opens
 11. Add scrolling container for message history
 12. Add header with title and close button to panel
-13. Import ChatPanel component in `/src/app/lore/page.tsx`
-14. Add state to control panel visibility in lore page
+13. Import ChatPanel component in `/src/app/planner/page.tsx`
+14. Add state to control panel visibility in planner page
 15. Update "Where are we" button to toggle panel
-16. Add ChatPanel component to lore page JSX
+16. Add ChatPanel component to planner page JSX
 17. Test button opens side panel correctly
 18. Verify welcome message appears when panel opens
 19. Test sending messages and receiving responses

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -8,7 +8,7 @@ import { redirect } from "next/navigation";
 import { ScrollText } from "lucide-react";
 import { ChatPanel } from "@/components/ChatPanel";
 
-export default function LorePage() {
+export default function PlannerPage() {
   const { user, loading } = useAuth();
   const [chatOpen, setChatOpen] = useState(false);
 
@@ -29,24 +29,24 @@ export default function LorePage() {
       <main className="container max-w-screen-2xl py-10">
         <div className="space-y-2 pb-8 pt-4 md:space-y-4 md:pb-10">
           <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
-            Lore Builder
+            Task Planner
           </h1>
           <p className="text-muted-foreground max-w-[650px]">
-            Design and develop your tabletop role-playing game campaign world.
+            Plan and track your tasks effectively.
           </p>
         </div>
 
         <Card className="w-full max-w-md mx-auto">
           <CardHeader>
-            <CardTitle>Lore Builder</CardTitle>
+            <CardTitle>Task Planner</CardTitle>
             <CardDescription>
-              Create the foundation of your TTRPG campaign.
+              Organize tasks and stay productive.
             </CardDescription>
           </CardHeader>
           <CardContent className="flex justify-center py-6">
             <Button size="lg" className="w-full max-w-xs" onClick={() => setChatOpen(true)}>
               <ScrollText className="mr-2 h-5 w-5" />
-              Build My Campaign
+              Start Planning
             </Button>
           </CardContent>
         </Card>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -35,7 +35,7 @@ export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
       setMessages([
         {
           role: "assistant",
-          content: "Hello! I&apos;m your Lore Builder assistant. I can help you rapidly develop the seed and roots of your TTRPG campaign. What kind of world would you like to create?"
+          content: "Hello! I&apos;m your task planner assistant. I can help you organize and prioritize your tasks. What would you like to work on today?"
         }
       ]);
     }
@@ -62,7 +62,7 @@ export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
       
       // Create the prompt with conversation history for context
       const conversationHistory = messages.map(msg => `${msg.role}: ${msg.content}`).join("\n");
-      const prompt = `You are a Lore Builder, an AI assistant that helps tabletop role-playing game (TTRPG) game masters rapidly develop the seed and roots of their campaigns. Help the user create compelling settings, characters, factions, and plot hooks for their TTRPG campaign. Be creative, ask insightful questions, and provide detailed suggestions to help build a rich campaign world.\n\nConversation history:\n${conversationHistory}\n\nUser: ${message}\nAssistant:`;
+      const prompt = `You are a Task Planner, an AI assistant that helps users organize and prioritize their work. Provide helpful suggestions to break down tasks, set priorities, and create an effective plan.\n\nConversation history:\n${conversationHistory}\n\nUser: ${message}\nAssistant:`;
       
       // Stream the response and update the UI with each chunk
       await streamTextGenerationWithState(
@@ -119,10 +119,10 @@ export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
         <SheetHeader className="px-4 py-3 border-b">
           <div className="flex items-center">
             <ScrollText className="h-5 w-5 mr-2 text-primary" />
-            <SheetTitle>Lore Builder</SheetTitle>
+            <SheetTitle>Task Planner</SheetTitle>
           </div>
           <SheetDescription>
-            I&apos;ll help you craft your campaign world
+            I&apos;ll help you manage and track your tasks
           </SheetDescription>
           <div className="mt-2">
             <div className="text-sm text-muted-foreground mb-1">AI Model:</div>

--- a/src/components/ui/main-nav.tsx
+++ b/src/components/ui/main-nav.tsx
@@ -70,17 +70,17 @@ export function MainNav({ items }: MainNavProps = {}) {
             <>
               <NavigationMenuItem>
                 <NavigationMenuLink asChild>
-                  <Link 
-                    href="/lore" 
+                  <Link
+                    href="/planner"
                     className={cn(
                       navigationMenuTriggerStyle(),
                       "transition-colors",
-                      pathname === "/lore" 
+                      pathname === "/planner"
                         ? "text-foreground" 
                         : "text-muted-foreground hover:text-foreground/90"
                     )}
                   >
-                    Lore
+                    Planner
                   </Link>
                 </NavigationMenuLink>
               </NavigationMenuItem>


### PR DESCRIPTION
## Summary
- rename `lore` route folder to `planner`
- update page component to `PlannerPage`
- refresh UI text for task planning
- adjust ChatPanel assistant prompts for tasks
- update navigation links and documentation

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c668e83e88326b4fb0113319981f3