### PR TITLE
Update planner docs

### DIFF
--- a/docs/SidePanelChat.md
+++ b/docs/SidePanelChat.md
@@ -1,13 +1,13 @@
-# Technical Specification: OpenAI Chat Side Panel for "Where are we" Button
+# Technical Specification: OpenAI Chat Side Panel for Planner Page
 
 ## Overview
-We'll implement a side panel that slides in from the right when the user clicks the "Where are we" button. This panel will contain a chat interface where users can interact with OpenAI to learn about their location in the fictional world.
+We'll implement a side panel that slides in from the right when the user clicks the "Plan with AI" button on the Planner page. This panel will contain a chat interface where users can interact with OpenAI to organize their tasks and refine upcoming activities.
 
 ## Component Structure
 1. Create a new `ChatPanel` component for the side panel
 2. Create a `ChatMessage` component to render individual messages
 3. Create a `ChatInput` component for user input
-4. Update the lore page to use these components
+4. Update the Planner page to use these components
 
 ## Detailed Specifications
 
@@ -40,9 +40,9 @@ Key features:
 - Disable input while waiting for AI response
 - Handle Enter key to send message
 
-### 4. Update Lore Page
-Location: `/src/app/lore/page.tsx`
-Purpose: Add the chat panel and connect it to the "Where are we" button
+### 4. Update Planner Page
+Location: `/src/app/planner/page.tsx`
+Purpose: Add the chat panel and connect it to the "Plan with AI" button
 
 Key changes:
 - Import the ChatPanel component
@@ -60,7 +60,7 @@ The following state will be needed:
 We'll use the existing OpenAI integration:
 - Use the `streamTextGenerationWithState` function from `streamClient.ts`
 - Build conversation history to provide context
-- Use a system prompt that sets the context for the chat about the fictional world
+- Use a system prompt that sets the context for planning tasks and schedules
 
 ## UI/UX Considerations
 - Add a smooth animation for the panel sliding in/out
@@ -92,15 +92,15 @@ We'll use the existing OpenAI integration:
 7. Add scrolling container for the message history
 8. Add a header with title and close button
 
-### 4. Update the Lore Page
-1. Import the ChatPanel component in `/src/app/lore/page.tsx`
+### 4. Update the Planner Page
+1. Import the ChatPanel component in `/src/app/planner/page.tsx`
 2. Add state to control the panel's visibility
-3. Update the "Where are we" button to toggle the panel
+3. Update the "Plan with AI" button to toggle the panel
 4. Add the ChatPanel component to the JSX
 5. Pass the necessary props to control the panel
 
 ### 5. Test the Implementation
-1. Verify that the "Where are we" button opens the side panel
+1. Verify that the "Plan with AI" button opens the side panel
 2. Confirm that the welcome message appears when the panel opens
 3. Test sending messages and receiving responses
 4. Verify that the streaming responses work correctly
@@ -119,10 +119,10 @@ IMPLEMENTATION CHECKLIST:
 10. Add welcome message when panel first opens
 11. Add scrolling container for message history
 12. Add header with title and close button to panel
-13. Import ChatPanel component in `/src/app/lore/page.tsx`
-14. Add state to control panel visibility in lore page
-15. Update "Where are we" button to toggle panel
-16. Add ChatPanel component to lore page JSX
+13. Import ChatPanel component in `/src/app/planner/page.tsx`
+14. Add state to control panel visibility in Planner page
+15. Update "Plan with AI" button to toggle panel
+16. Add ChatPanel component to Planner page JSX
 17. Test button opens side panel correctly
 18. Verify welcome message appears when panel opens
 19. Test sending messages and receiving responses


### PR DESCRIPTION
## Summary
- rename references to the lore page path
- adjust descriptions to match the new Planner page
- remove references to the fictional-world/TTRPG scenario

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c669105288326a3f82c531188197a