### PR TITLE
Update README with task planner chat bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Origins is a full-stack Next.js application that integrates Model Context Protoc
 - Next.js App Router with React & TypeScript
 - Model Context Protocol (MCP) API integration
 - OpenAI API integration for text generation and embeddings
+- Interactive task-planner chat feature powered by OpenAI
 - GitHub OAuth login and user session management
 - Supabase client for authentication, database, and storage
 - Custom UI components library (Button, Card, Dialog, Form, Input, Label, LoginForm, Sheet)


### PR DESCRIPTION
## Summary
- mention the new task‑planner chat feature in the README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c66923b088326b5904facb69e49a0