### PR TITLE
Add GPT-4.1 Nano model

### DIFF
--- a/docs/openai-integration.md
+++ b/docs/openai-integration.md
@@ -14,8 +14,9 @@ You can add this to your `.env.local` file for local development. The OpenAI int
 
 ## Available Models
 
-The default model for text generation is `gpt-4o-mini`. The following models are supported:
+The default model for text generation is `gpt-4.1-nano`. The following models are supported:
 
+- `gpt-4.1-nano` - Tiny and fast GPT-4.1 model
 - `gpt-4o-mini` - Smaller, faster version of GPT-4o
 - `gpt-4o` - Full-sized GPT-4o model
 
@@ -37,7 +38,7 @@ const response = await fetch('/api/openai', {
   body: JSON.stringify({
     text: 'Your prompt here',
     type: 'completion',  // Optional, defaults to 'completion'
-    model: 'gpt-4o-mini',// Optional, defaults to 'gpt-4o-mini'
+    model: 'gpt-4.1-nano',// Optional, defaults to 'gpt-4.1-nano'
     maxTokens: 500       // Optional, defaults to 500
   }),
 });
@@ -59,7 +60,7 @@ const response = await fetch('/api/openai', {
   body: JSON.stringify({
     text: 'Your prompt here',
     type: 'completion',
-    model: 'gpt-4o-mini', // Optional, defaults to 'gpt-4o-mini'
+    model: 'gpt-4.1-nano', // Optional, defaults to 'gpt-4.1-nano'
     maxTokens: 500,       // Optional, defaults to 500
     stream: true          // Enable streaming
   }),
@@ -110,7 +111,7 @@ function ChatComponent() {
         });
       },
       {
-        model: 'gpt-4o-mini',
+        model: 'gpt-4.1-nano',
         maxTokens: 1000,
         onComplete: (fullText) => console.log('Stream complete')
       }

--- a/src/config/aiModels.ts
+++ b/src/config/aiModels.ts
@@ -1,6 +1,7 @@
 export const AI_MODELS = {
-  default: 'gpt-4o-mini',
+  default: 'gpt-4.1-nano',
   options: [
+    { id: 'gpt-4.1-nano', name: 'GPT-4.1 Nano', description: 'Tiny and fast GPT‑4.1 model' },
     { id: 'gpt-4o-mini', name: 'GPT-4o Mini', description: 'Smaller, faster version of GPT-4o' },
     { id: 'gpt-4o', name: 'GPT-4o', description: 'Full-sized GPT-4o model' },
     // Additional models can be added here in the future

--- a/src/lib/openaiService.ts
+++ b/src/lib/openaiService.ts
@@ -8,13 +8,13 @@ const openai = new OpenAI({
 /**
  * Generate text using OpenAI's GPT model
  * @param prompt The prompt to send to the API
- * @param model The model to use (defaults to gpt-4o-mini)
+ * @param model The model to use (defaults to gpt-4.1-nano)
  * @param maxTokens Maximum number of tokens to generate
  * @param stream Whether to stream the response (defaults to false)
  */
 export async function generateText(
   prompt: string,
-  model: string = 'gpt-4o-mini',
+  model: string = 'gpt-4.1-nano',
   maxTokens: number = 500,
   stream: boolean = false
 ) {


### PR DESCRIPTION
## Summary
- set `gpt-4.1-nano` as the default AI model
- document the new model option in OpenAI integration docs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc8e5f5808326b3ac4b37f8bef6fd