### PR TITLE
Fix home page Get Started link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
           </p>
           <div className="mt-6 flex justify-center">
             <Button size="lg" asChild>
-              <a href="/auth/login">Get Started</a>
+              <a href="/auth">Get Started</a>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fix the Get Started link on the home page to point to `/auth`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdc7c50448326979fb2fbf09c2ca8